### PR TITLE
UI redesign: 'Plates' concept synthesis + interactive prototype

### DIFF
--- a/notes/ui-design/REDESIGN_CONCEPT.md
+++ b/notes/ui-design/REDESIGN_CONCEPT.md
@@ -1,0 +1,258 @@
+# Plates — a considered interface concept for Elements
+
+Date: 2026-06-09
+Status: concept proposal, with working prototype
+Companion artifact: `concept-prototype.html` (open it in a browser; everything described below is interactive)
+
+This document takes the vision captured in `UI_OVERHAUL_DESIGN.md` and the visual language
+distilled in `EUCLID_STYLE_NOTES.md`, and commits to a specific design. Where the earlier
+notes deliberately left questions open, this one answers them — so the answers can be
+argued with concretely rather than abstractly.
+
+---
+
+## 1. The organizing idea: the plate
+
+The central conceptual move is to name the primary surface.
+
+It is not a "view", a "page", or a "workspace". It is a **plate** — in the sense of a
+printed mathematical illustration plate: a single composed surface on which a proposition
+and its figure appear together as one object.
+
+This one word resolves several tensions from the vision notes at once:
+
+- A plate is **composed**, not assembled from panels. Layout decisions are compositional
+  (where does the text sit relative to the figure?) rather than structural (which pane
+  does this go in?).
+- A plate has **one ground colour**. The background is not neutral app-chrome; it is the
+  plate's ground, and the figure and text are inked onto it. This is what makes palette
+  permutation per-predicate natural rather than gimmicky: *different plates are printed
+  in different colourways*.
+- A plate is **flat**. Nothing hovers over a printed plate. The strictly-2D rule stops
+  being a stylistic prohibition and becomes a property of the metaphor: surfaces beside
+  the plate (strip, index, underside) take real space from it.
+- A plate is **worth contemplating**. The hero entry, the reading mode, the restraint —
+  these all follow from treating each predicate as something with the dignity of a
+  printed proposition.
+
+Everything else in the design is staged relative to the plate:
+
+```
+            ┌────────────────────────────────────────────┐
+            │  STRIP      elements · scratchpad · ⟨name⟩ · search
+            ├────────────────────────────────────────────┤
+            │  (INDEX     reveals downward from the strip)
+            ├────────────────────────────────────────────┤
+            │                                            │
+  SCRATCH ⟸ │                THE PLATE                   │
+  (slides   │     text ◀──── the tether ────▶ figure     │
+   in from  │                                            │
+   the left)│                                            │
+            ├────────────────────────────────────────────┤
+            │  (UNDERSIDE reveals upward from the floor) │
+            └────────────────────────────────────────────┘
+```
+
+Five surfaces, one plane. Nothing overlaps anything, ever.
+
+---
+
+## 2. The tether: colour is the binding, hover is the emphasis
+
+The vision notes ask for a "felt connection" between code and diagram. The considered
+answer is that the connection should be **ambient first, interactive second**:
+
+1. **Ambient binding (always on).** Every point name is set in a colour, and that colour
+   is consistent between the text and the figure's labels. You can read the
+   correspondence without touching anything — exactly as Byrne intended when he replaced
+   letters with coloured shapes. This is the primary binding.
+
+2. **Interactive emphasis (on hover).** Hovering either surface answers the question
+   *"which one is this?"* by **recession, not decoration**: everything that is not the
+   hovered entity drops to low ink, on both surfaces simultaneously. No glows, no
+   tooltips, no pulsing. The plate stays a plate; it simply concentrates.
+
+   - hover a point letter (either surface) → that point stays inked everywhere, all else recedes
+   - hover a body clause → the shape it denotes stays inked, the clause underlines
+   - hover the proof tick → it quietly extends into "view trace" (the sanctioned door
+     to the underside)
+
+3. **Navigation by reading.** Predicate words in body clauses (e.g. `eq-triangle` inside
+   `eq-lines`) are navigable: the text is an active surface, per §15.5 of the vision notes.
+
+Rule worth stating explicitly: **colour in the text is reserved for the binding.**
+No syntax highlighting in reading mode. Keywords, punctuation, and predicate names take
+the plate's ink; only point references take binding colours. Syntax colouring is an
+editor convention and belongs, sparingly, to the scratchpad.
+
+---
+
+## 3. Composition of the plate
+
+### 3.1 The figure owns the ground
+
+The SVG canvas is the entire plate. The *named points* are composed into a zone on the
+right (roughly the right third, vertically centred); the *geometry* — lines, circles —
+runs wherever it must, off all four edges. Lines are always drawn infinite. Circles are
+always drawn whole, even when mostly off-plate. The figure is never clipped to a frame,
+because there is no frame.
+
+### 3.2 The text is placed, not docked
+
+The clause text sits at a fixed left anchor with a *chosen* vertical position:
+
+- candidate positions are a small finite set (~12 y-positions)
+- each is scored by sampling a grid of points against the figure's strokes and points
+- least-overlap wins, with hysteresis (only move when meaningfully better)
+- re-evaluated on load and on `pointerup` after a drag — never during one
+
+The settle rhythm after a drag is a fixed, legible sequence:
+
+> release → the figure re-fits its point cluster to the zone (≈380ms) → the text
+> chooses its position (≤450ms slide)
+
+This rhythm is the interface's signature move. It should feel like the plate quietly
+re-composing itself — a letterpress printer nudging the type to fit the cut.
+
+### 3.3 Text treatment in reading mode
+
+- display type, generous leading, wide tracking, set in uppercase
+- **uppercase is a visual treatment only** — the source remains lowercase, and copy/paste
+  yields lowercase source. The text *is* the code; it is merely dressed for the page.
+- head clause flush left; body clauses indented one em-quad; no box, no background,
+  no border — if the placement algorithm cannot find clear ground, the *figure* yields
+  (the point zone shrinks), not the text.
+
+### 3.4 Proof status in reading mode
+
+A single small tick after the head clause, in a restrained proof-green that sits outside
+the binding palette. Silent when proven. On hover it extends to "view trace"; activating
+it opens the underside. A failed lemma sets the tick in vermilion ✗ — same size, same
+position, no banner. The plate must stay beautiful when wrong (vision §17.8).
+
+---
+
+## 4. Colourways: the material Byrne palette
+
+One palette, five inks, used as **roles, not assignments**:
+
+| token | value | character |
+|---|---|---|
+| `paper` | `#f3eee2` | warm stock, not screen-white |
+| `ink` | `#1b1813` | near-black, warm |
+| `ultramarine` | `#1d3fbf` | Byrne blue, printed not digital |
+| `vermilion` | `#d93a1a` | Byrne red-orange |
+| `gamboge` | `#e09c14` | Byrne yellow — the third primary the old draft was missing |
+
+A **colourway** is an assignment of these inks to the plate's roles (ground, figure
+strokes, point bindings, label ink). Each predicate gets a colourway; neighbouring
+predicates in browse order should differ. Examples implemented in the prototype:
+
+- `eq-triangle`: paper ground, ultramarine/vermilion figure, full-colour bindings
+- `eq-lines`: vermilion ground, white figure, **black/white bindings only** —
+  on a hot ground the bindings drop to two values; legibility beats system purity
+
+Mode colourways: the scratchpad prints on `ink` ground with `gamboge` accent — a genuine
+permutation of the same five inks, not a new hue (this replaces the purple from
+`STYLE_TOKENS_DRAFT.md`, which broke the palette's discipline). The strip and underside
+also live on `ink`, so the plate is always the brightest surface on screen — hierarchy
+by ground colour, not by border.
+
+Auxiliary (derived, non-argument) points print smaller and quieter than argument points —
+the figure carries its own hierarchy: arguments loud, scaffolding quiet, sub-construction
+shapes at ~30% ink.
+
+---
+
+## 5. The five surfaces
+
+### 5.1 Strip
+Tiles in the established vocabulary: `ELEMENTS | SCRATCHPAD | ⟨predicate⟩ ◀ ▶ | SEARCH`.
+The viewer tile carries the current predicate name and prev/next, which walk the
+topological order of the construction dependency graph (vision §15.4) — the book reads
+in dependency order, no files, no folders. Absent until first interaction (see 5.6).
+
+### 5.2 Index (search)
+The strip grows downward an extra row; the plate cedes the space. Typing filters
+predicate cards — each card a miniature plate in its own colourway, rendered live from
+the same geometry that renders the full plate. The index is a contact sheet of plates.
+
+### 5.3 Scratchpad
+Lives permanently to the **left** of the viewer; opening it slides the whole track right
+(tab-like persistence, stable spatial metaphor, vision §17.2). It is unapologetically an
+editor: monospace, caret, gutter. Proof marks sit in the **left gutter** (✓ gamboge,
+✗ vermilion), checked live with a short debounce. Its diagram obeys the same plate rules
+on the same plane.
+
+### 5.4 Underside (boffin panel)
+Opens with `` ` `` or a near-invisible `§` in the floor corner, or via "view trace".
+The plate gives up its lower band; nothing floats. Ink ground, three columns:
+**construction plan · solver · proof trace**. The plan is printed in the planner's own
+vocabulary (`α ≔ circle(a ; b)`, `c ≔ meet(α, β) ▸ upper`) — the underside speaks
+machine, the plate speaks Euclid.
+
+### 5.5 Hero entry
+First load is a full-bleed plate of a curated construction with `ELEMENTS` set large on
+the ground and one whispered caption: *drag the figure*. Touching the figure starts the
+sequence: title fades, strip slides in (taking real space), text settles into place.
+The user's first act in the system is doing geometry, not reading chrome.
+
+### 5.6 Motion grammar
+Three durations, one easing family, all motion is reallocation of space on the plane:
+
+- **160ms** — emphasis (hover recession)
+- **380–450ms** — re-composition (strip/index/underside taking space; figure re-fit; text placement)
+- **600ms** — travel (scratchpad slide)
+
+Nothing fades in *over* anything. Opacity transitions are reserved for ink (title,
+text) on an already-settled ground.
+
+---
+
+## 6. Answers to the open questions (vision §18)
+
+| open question | committed answer |
+|---|---|
+| animation grammar | three durations / one plane, §5.6 |
+| reading-fallback vs editing boundary | length moves text to the margin anchor (no chrome); *intent* (click-to-edit / scratchpad) brings the editor; mode is never implied by layout alone |
+| code surface per mode | reading: dressed source (display type, uppercase treatment, binding colours only); editing: honest monospace editor with gutter |
+| diagram surface per mode | identical plate rules in both; only the colourway changes |
+| shared interaction | the tether (§2): ambient colour + recession hover, symmetric in both directions |
+| auxiliary detail reveal | underside only, three columns, entered by `` ` ``/§/view-trace |
+| navigation | strip tile prev/next over topological order; index cards; predicate mentions in text are links |
+| lemma layers | not in the default plate; an index-style reveal listing lemma slices is the candidate, deliberately deferred |
+| how much current UI survives | conceptually none of the three-panel layout; all of the runtime/worker machinery |
+| page, spread, or canvas? | **plate** |
+
+---
+
+## 7. What the prototype proves (and what it fakes)
+
+`concept-prototype.html` is one self-contained file, no dependencies, real geometry.
+
+Proven for real:
+- both constructions are computed constructively (I.1 and I.2) and fully draggable
+- the tether: bidirectional hover recession + ambient colour binding
+- adaptive text placement with scoring + hysteresis, and the release→refit→place rhythm
+- colourway permutation across predicates and modes
+- all five surfaces tiling on one plane, including the hero sequence
+- live index miniatures rendered from the same data as the plates
+
+Faked, knowingly:
+- the scratchpad "interpreter" is a toy relaxation pass, not the real KB pipeline
+- proof traces / solver reports are static demo text
+- only two predicates + stub cards; no graph-ordered browsing yet
+- no in-text predicate-mention navigation yet
+
+## 8. Suggested implementation path
+
+1. Extract the colourway/typography tokens into `src/assets/` as CSS custom properties
+   (replacing `STYLE_TOKENS_DRAFT.md`'s values with the material palette above).
+2. Build `PlateView.vue` against the existing solver/planner output: figure-fit,
+   text placement, tether. This is the heart and can ship while the old three-panel
+   `MainView` still exists behind a flag.
+3. Strip + index over `useKB`'s namespace tree, ordered topologically.
+4. Scratchpad as the existing `EditorPane` re-skinned into the ink colourway with the
+   gutter moved left.
+5. Underside fed by the data the boffin panel already implies (plan, solver, worker
+   verification results).

--- a/notes/ui-design/concept-prototype.html
+++ b/notes/ui-design/concept-prototype.html
@@ -1,0 +1,838 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ELEMENTS — interface concept prototype</title>
+<!--
+  ELEMENTS · UI redesign concept prototype
+  ========================================
+  A single-file, interactive sketch of the reimagined interface described in
+  UI_OVERHAUL_DESIGN.md / EUCLID_STYLE_NOTES.md / REDESIGN_CONCEPT.md.
+
+  What this demonstrates:
+    1. Hero entry      — a full-bleed plate; touching the figure reveals the interface
+    2. Reading plate   — code as composed typography, diagram owning the whole canvas,
+                         live draggable geometry, colour-bound code<->diagram hover,
+                         adaptive code positioning with hysteresis
+    3. Top strip       — ELEMENTS | SCRATCHPAD | <predicate> ◀ ▶ | SEARCH (tile vocabulary)
+    4. Search reveal   — header expands downward, predicate cards with live miniatures
+    5. Scratchpad      — slides in from the left; recognisable editor, gutter proof marks,
+                         palette permutation; the text is (crudely) live-interpreted
+    6. Boffin panel    — backtick ` or the § glyph, or "view trace" on a proof tick;
+                         the page gives up its lower space to show the machinery
+
+  All geometry is computed for real (eq-triangle is Euclid I.1, eq-lines is Euclid I.2).
+  Everything tiles on one plane: no overlays, no shadows, no z-order.
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@500;600;700&family=Archivo+Black&family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
+<style>
+/* ============================== tokens ============================== */
+:root {
+  /* material Byrne palette — printed-ink character, not screen-digital */
+  --paper:      #f3eee2;
+  --paper-hi:   #faf7ee;
+  --ink:        #1b1813;
+  --ink-soft:   #4d463b;
+  --ultra:      #1d3fbf;   /* ultramarine */
+  --verm:       #d93a1a;   /* vermilion   */
+  --gamboge:    #e09c14;   /* gamboge     */
+  --proof-ok:   #2c7a3f;
+
+  --font-display: 'Archivo Black', 'Archivo', sans-serif;
+  --font-ui:      'Archivo', sans-serif;
+  --font-code:    'IBM Plex Mono', monospace;
+
+  --strip-h: 54px;
+  --search-h: 178px;
+  --boffin-h: 236px;
+
+  --t-fast: 160ms;
+  --t-med:  420ms cubic-bezier(.22,.9,.3,1);
+  --t-slow: 600ms cubic-bezier(.22,.9,.3,1);
+}
+
+* { box-sizing: border-box; }
+html, body { margin:0; padding:0; height:100%; overflow:hidden; }
+body { font-family: var(--font-ui); background: var(--ink); color: var(--ink); }
+
+#app { display:flex; flex-direction:column; height:100vh; }
+
+/* ============================== top strip ============================== */
+#strip {
+  height:0; overflow:hidden; flex:none;
+  transition: height var(--t-med);
+  background: var(--ink);
+  display:flex; gap:3px; padding:0;
+}
+#app.revealed #strip { height: var(--strip-h); }
+.tile {
+  display:flex; align-items:center; gap:14px;
+  padding:0 22px; cursor:pointer; user-select:none;
+  background: var(--ink); color: var(--paper);
+  font-family: var(--font-display); font-size:15px;
+  letter-spacing:.14em; text-transform:uppercase;
+  border:0; outline-offset:-4px;
+}
+.tile + .tile { border-left:3px solid var(--paper); }
+.tile:hover { color: var(--gamboge); }
+.tile.active { background: var(--ultra); color: var(--paper); }
+.tile.brand { color: var(--verm); cursor:default; }
+.tile.brand:hover { color: var(--verm); }
+#tile-viewer { flex:1; }
+#tile-viewer .navarrow {
+  font-family: var(--font-ui); font-weight:700; font-size:17px;
+  padding:2px 8px; cursor:pointer; opacity:.65;
+}
+#tile-viewer .navarrow:hover { opacity:1; color: var(--gamboge); }
+#tile-viewer .vname { letter-spacing:.14em; }
+
+/* ============================== search reveal ============================== */
+#search {
+  height:0; overflow:hidden; flex:none;
+  transition: height var(--t-med);
+  background: var(--ink); color: var(--paper);
+}
+#app.search-open #search { height: var(--search-h); }
+#search .inner { padding:14px 22px 18px; border-top:3px solid var(--paper); height:100%; }
+#search input {
+  width:100%; background:transparent; border:0; border-bottom:2px solid var(--paper);
+  color:var(--paper); font-family:var(--font-display); font-size:18px;
+  letter-spacing:.14em; text-transform:uppercase; padding:4px 0 8px; outline:none;
+}
+#search input::placeholder { color:var(--paper); opacity:.35; }
+#cards { display:flex; gap:14px; margin-top:14px; overflow-x:auto; }
+.card {
+  flex:none; width:172px; height:96px; position:relative; cursor:pointer;
+  border:2px solid var(--paper);
+}
+.card svg { width:100%; height:100%; display:block; }
+.card .cname {
+  position:absolute; left:8px; bottom:6px;
+  font-family:var(--font-display); font-size:12px; letter-spacing:.1em;
+  text-transform:uppercase; pointer-events:none;
+}
+.card:hover { border-color: var(--gamboge); }
+.card.stub { opacity:.55; cursor:default; }
+
+/* ============================== main track ============================== */
+#main { flex:1; min-height:0; overflow:hidden; position:relative; }
+#track {
+  display:flex; width:200%; height:100%;
+  transform: translateX(-50%);
+  transition: transform var(--t-slow);
+}
+#app.scratch-open #track { transform: translateX(0); }
+.pane { width:50%; height:100%; position:relative; overflow:hidden; }
+
+/* ============================== the plate ============================== */
+#plate { background: var(--paper); }
+#plate svg.canvas { position:absolute; inset:0; width:100%; height:100%; }
+
+#hero-title {
+  position:absolute; left:6%; top:10%;
+  font-family:var(--font-display); color:var(--ink);
+  font-size: clamp(64px, 11vw, 160px); letter-spacing:.06em;
+  pointer-events:none; transition: opacity 900ms ease;
+}
+#hero-hint {
+  position:absolute; left:6.4%; top: calc(10% + clamp(80px, 13vw, 190px));
+  font-family:var(--font-ui); font-weight:600; font-size:12px;
+  letter-spacing:.34em; text-transform:uppercase; color:var(--ink-soft);
+  pointer-events:none; transition: opacity 900ms ease;
+  animation: hint-pulse 2.6s ease-in-out infinite;
+}
+@keyframes hint-pulse { 50% { opacity:.35; } }
+#app.revealed #hero-title, #app.revealed #hero-hint { opacity:0; animation:none; }
+
+/* --- code as composed typography (reading mode) --- */
+#codeblock {
+  position:absolute; left:48px; top:30%;
+  max-width: 34vw;
+  opacity:0; transition: opacity 800ms ease 250ms, top 500ms cubic-bezier(.22,.9,.3,1);
+  font-family: var(--font-display);
+  font-size: clamp(15px, 1.55vw, 24px);
+  line-height: 1.85; letter-spacing:.1em; text-transform:uppercase;
+  user-select:none;
+}
+#app.revealed #codeblock { opacity:1; }
+#codeblock .clause { white-space:nowrap; }
+#codeblock .clause.body { padding-left:1.6em; cursor:pointer; }
+#codeblock .clause.body:hover { color: var(--ink); }
+#codeblock .pt { cursor:pointer; transition: opacity var(--t-fast); }
+#codeblock .pred { }
+#codeblock.dimmed .pt:not(.hl), #codeblock.dimmed .pred { opacity:.3; }
+#codeblock .clause.body.hl { text-decoration: underline; text-underline-offset:.28em; text-decoration-thickness:3px; }
+
+/* proof tick — quiet by default, opens the trace on demand */
+.tick {
+  display:inline-block; margin-left:.7em; cursor:pointer;
+  font-family:var(--font-ui); font-weight:700; font-size:.62em;
+  letter-spacing:.18em; color:var(--proof-ok); vertical-align:.18em;
+}
+.tick .tlabel { display:none; }
+.tick:hover .tlabel { display:inline; margin-left:.6em; border-bottom:2px solid var(--proof-ok); }
+
+/* --- diagram --- */
+.canvas .shape { transition: opacity var(--t-fast); }
+.canvas .shape.dim { opacity:.30; }
+.canvas .shape.hl  { stroke-width:6px !important; }
+.canvas.dimmed .shape:not(.hl) { opacity:.18; }
+.canvas .ptdot { cursor:grab; }
+.canvas .ptdot.dragging { cursor:grabbing; }
+.canvas .ptdot.hl { stroke-width:4px; }
+.canvas .ptlabel {
+  font-family:var(--font-display); font-size:19px; letter-spacing:.04em;
+  text-transform:uppercase; pointer-events:none;
+}
+.canvas .aux .ptlabel { font-size:15px; opacity:.75; }
+
+/* ============================== scratchpad ============================== */
+#scratch { background: var(--ink); display:flex; }
+#scratch .editorcol {
+  width: 420px; flex:none; border-right:3px solid var(--paper);
+  display:flex; flex-direction:column;
+}
+#scratch .edhead {
+  padding:14px 18px 10px; color:var(--gamboge);
+  font-family:var(--font-display); font-size:13px; letter-spacing:.22em; text-transform:uppercase;
+}
+#scratch .edwrap { flex:1; display:flex; overflow:auto; }
+#gutter {
+  width:40px; flex:none; padding:12px 0; text-align:center;
+  font-family:var(--font-code); font-size:14px; line-height:1.75;
+  color:var(--paper); opacity:.9; user-select:none;
+}
+#gutter .ok { color:var(--gamboge); }
+#gutter .bad { color:var(--verm); font-weight:600; }
+#editor {
+  flex:1; padding:12px 14px 12px 0; margin:0; border:0; outline:none; resize:none;
+  background:transparent; color:var(--paper);
+  font-family:var(--font-code); font-size:14px; line-height:1.75;
+  white-space:pre; caret-color:var(--gamboge);
+}
+#scratch .scanvas { flex:1; position:relative; }
+#scratch .scanvas svg { position:absolute; inset:0; width:100%; height:100%; }
+
+/* ============================== boffin panel ============================== */
+#boffin {
+  height:0; overflow:hidden; flex:none;
+  transition: height var(--t-med);
+  background:var(--ink); color:var(--paper);
+}
+#app.boffin-open #boffin { height: var(--boffin-h); }
+#boffin .inner {
+  border-top:3px solid var(--paper); height:100%;
+  display:grid; grid-template-columns: 1fr 1fr 1.2fr; gap:0;
+}
+#boffin .col { padding:12px 18px; overflow:auto; border-left:2px solid #3a352c; }
+#boffin .col:first-child { border-left:0; }
+#boffin h3 {
+  margin:0 0 10px; font-family:var(--font-display); font-size:11px;
+  letter-spacing:.26em; text-transform:uppercase; color:var(--gamboge);
+}
+#boffin pre {
+  margin:0; font-family:var(--font-code); font-size:12px; line-height:1.65;
+  color:var(--paper); opacity:.92; white-space:pre-wrap;
+}
+#boffin-btn {
+  position:fixed; right:10px; bottom:8px; z-index:5;
+  background:none; border:0; cursor:pointer;
+  font-family:var(--font-code); font-size:14px; color:var(--ink-soft); opacity:.35;
+}
+#boffin-btn:hover { opacity:.9; }
+#app.scratch-open #boffin-btn, #app:not(.revealed) #boffin-btn { color:var(--paper); }
+</style>
+</head>
+<body>
+<div id="app">
+  <header id="strip">
+    <div class="tile brand">Elements</div>
+    <button class="tile" id="tile-scratch">Scratchpad</button>
+    <div class="tile active" id="tile-viewer">
+      <span class="navarrow" id="nav-prev">◀</span>
+      <span class="vname" id="viewer-name">eq-triangle</span>
+      <span class="navarrow" id="nav-next">▶</span>
+    </div>
+    <button class="tile" id="tile-search">Search</button>
+  </header>
+
+  <div id="search">
+    <div class="inner">
+      <input id="search-input" placeholder="predicate…" spellcheck="false">
+      <div id="cards"></div>
+    </div>
+  </div>
+
+  <main id="main">
+    <div id="track">
+      <!-- scratchpad lives to the LEFT; the viewer to the RIGHT (stable spatial metaphor) -->
+      <section class="pane" id="scratch">
+        <div class="editorcol">
+          <div class="edhead">Scratchpad</div>
+          <div class="edwrap">
+            <div id="gutter"></div>
+            <textarea id="editor" spellcheck="false"></textarea>
+          </div>
+        </div>
+        <div class="scanvas"><svg id="scratch-svg"></svg></div>
+      </section>
+
+      <section class="pane" id="plate">
+        <svg class="canvas" id="svg"></svg>
+        <div id="hero-title">ELEMENTS</div>
+        <div id="hero-hint">drag the figure</div>
+        <div id="codeblock"></div>
+      </section>
+    </div>
+  </main>
+
+  <div id="boffin">
+    <div class="inner">
+      <div class="col"><h3>Construction plan</h3><pre id="bof-plan"></pre></div>
+      <div class="col"><h3>Solver</h3><pre id="bof-solver"></pre></div>
+      <div class="col"><h3>Proof trace</h3><pre id="bof-trace"></pre></div>
+    </div>
+  </div>
+  <button id="boffin-btn" title="boffin panel (`)">§</button>
+</div>
+
+<script>
+/* ======================= small vector helpers ======================= */
+const V = {
+  add:(p,q)=>({x:p.x+q.x, y:p.y+q.y}),
+  sub:(p,q)=>({x:p.x-q.x, y:p.y-q.y}),
+  mul:(p,s)=>({x:p.x*s, y:p.y*s}),
+  dist:(p,q)=>Math.hypot(p.x-q.x, p.y-q.y),
+  norm:(p)=>{ const d=Math.hypot(p.x,p.y)||1; return {x:p.x/d, y:p.y/d}; },
+  rot:(p,c,ang)=>{ const s=Math.sin(ang), co=Math.cos(ang), dx=p.x-c.x, dy=p.y-c.y;
+                   return {x:c.x+dx*co-dy*s, y:c.y+dx*s+dy*co}; }
+};
+
+/* ======================= predicate data ======================= */
+/* Plate themes are permutations of the same material palette. */
+const THEMES = {
+  'eq-triangle': { bg:'#f3eee2', ink:'#1b1813', strokes:['#1d3fbf','#d93a1a','#e09c14','#1b1813'],
+                   pt:'#1b1813', ptRim:'#f3eee2', code:['#d93a1a','#1d3fbf','#e09c14','#1b1813'] },
+  'eq-lines':    { bg:'#d93a1a', ink:'#1b1813', strokes:['#fbf8f1','#fbf8f1','#1b1813','#fbf8f1','#fbf8f1'],
+                   pt:'#1b1813', ptRim:'#fbf8f1', code:['#1b1813','#fbf8f1','#1b1813','#fbf8f1','#1b1813','#fbf8f1'] },
+};
+
+const PREDS = {
+  'eq-triangle': {
+    args:['a','b','c'],
+    free: { a:{x:0,y:0}, b:{x:1,y:0} },
+    derive(p){ p.c = V.rot(p.b, p.a, -Math.PI/3); },
+    body: [
+      { text:['circle','a','b','c'], ref:'s0' },
+      { text:['circle','b','a','c'], ref:'s1' },
+    ],
+    shapes(p){ return [
+      { kind:'circle', c:p.a, r:V.dist(p.a,p.b), ref:'s0', ci:0 },
+      { kind:'circle', c:p.b, r:V.dist(p.b,p.a), ref:'s1', ci:1 },
+    ];},
+    aux: [],
+    plan: ['place  a', 'place  b',
+           'α ≔ circle(a ; b)', 'β ≔ circle(b ; a)',
+           'c ≔ meet(α, β) ▸ upper'],
+    solver: 'dof            4 free / 2 derived\nconstraints    2 (on-circle ×2)\nresidual       0.0 (constructive)\nplan           exact · no numeric fallback',
+    trace: '? eq-lines a b a c : circle a b c\n  ✓ unfold eq-lines/4 → eq-triangle…\n  ✓ circle a b c        [premise]\n  ✓ circle a c b        [radii-comm]\n  ✓ eq-lines a b a c    [on-circle-eq]\n\nQ.E.D. — 4 steps, 0.8 ms',
+  },
+  'eq-lines': {
+    args:['b','c','a','l'],
+    free: { a:{x:0,y:0}, b:{x:0.62,y:0.16}, c:{x:0.30,y:-0.42} },
+    derive(p){
+      p.d = V.rot(p.b, p.a, Math.PI/3);                       // eq-triangle d a b
+      p.g = V.add(p.b, V.mul(V.norm(V.sub(p.b,p.d)), V.dist(p.b,p.c)));  // circle b c g ∩ line d b
+      p.l = V.add(p.d, V.mul(V.norm(V.sub(p.a,p.d)), V.dist(p.d,p.g)));  // circle d g l ∩ line d a
+    },
+    body: [
+      { text:['eq-triangle','d','a','b'], ref:'s0' },
+      { text:['line','d','a','l'], ref:'s1' },
+      { text:['line','d','b','g'], ref:'s2' },
+      { text:['circle','b','c','g'], ref:'s3' },
+      { text:['circle','d','g','l'], ref:'s4' },
+    ],
+    shapes(p){ return [
+      { kind:'circle', c:p.d, r:V.dist(p.d,p.a), ref:'s0', ci:0, dim:true },
+      { kind:'circle', c:p.a, r:V.dist(p.a,p.d), ref:'s0', ci:0, dim:true },
+      { kind:'line', a:p.d, b:p.a, ref:'s1', ci:1 },
+      { kind:'line', a:p.d, b:p.b, ref:'s2', ci:1 },
+      { kind:'circle', c:p.b, r:V.dist(p.b,p.c), ref:'s3', ci:3 },
+      { kind:'circle', c:p.d, r:V.dist(p.d,p.g), ref:'s4', ci:4 },
+    ];},
+    aux: ['d','g'],
+    plan: ['place  a · b · c',
+           'd ≔ apex(eq-triangle a b)',
+           'ℓ₁ ≔ line(d, a)', 'ℓ₂ ≔ line(d, b)',
+           'γ ≔ circle(b ; c)', 'g ≔ meet(ℓ₂, γ) ▸ far',
+           'δ ≔ circle(d ; g)', 'l ≔ meet(ℓ₁, δ) ▸ far'],
+    solver: 'dof            6 free / 6 derived\nconstraints    5\nresidual       2.1e-12\nplan           exact · 8 steps',
+    trace: '? eq-lines b c a l : …\n  ✓ eq-triangle d a b   [I.1]\n  ✓ eq-lines d a d b    [equilateral]\n  ✓ eq-lines b c b g    [radii γ]\n  ✓ eq-lines d g d l    [radii δ]\n  ✓ between d b g · between d a l\n  ✓ eq-lines a l b g    [subtraction]\n  ✓ eq-lines b c a l    [transitivity]\n\nQ.E.D. — 7 steps, 2.3 ms',
+  },
+};
+const PRED_ORDER = ['eq-triangle','eq-lines'];
+
+/* ======================= app state ======================= */
+const app = document.getElementById('app');
+const svg = document.getElementById('svg');
+const codeblock = document.getElementById('codeblock');
+const state = {
+  current: 'eq-triangle',
+  pts: {},            // model coords for current predicate
+  tf: { k:300, ox:0, oy:0 },
+  revealed: false,
+  codeTop: null,
+};
+
+const $ = s => document.querySelector(s);
+const SVGNS = 'http://www.w3.org/2000/svg';
+function el(name, attrs, parent){
+  const e = document.createElementNS(SVGNS, name);
+  for (const k in attrs) e.setAttribute(k, attrs[k]);
+  if (parent) parent.appendChild(e);
+  return e;
+}
+
+/* ======================= transform ======================= */
+function plateSize(){ const r = $('#plate').getBoundingClientRect(); return { w:r.width, h:r.height }; }
+function toScreen(p){ return { x: p.x*state.tf.k + state.tf.ox, y: p.y*state.tf.k + state.tf.oy }; }
+function toModel(p){ return { x:(p.x-state.tf.ox)/state.tf.k, y:(p.y-state.tf.oy)/state.tf.k }; }
+
+/* Fit the named points into the right-hand zone of the plate.
+   The geometry itself is welcome to spill across the whole page. */
+function targetTf(){
+  const { w, h } = plateSize();
+  const pred = PREDS[state.current];
+  const names = pred.args.concat(pred.aux);
+  let x0=1e9,y0=1e9,x1=-1e9,y1=-1e9;
+  for (const n of names){ const p = state.pts[n];
+    x0=Math.min(x0,p.x); y0=Math.min(y0,p.y); x1=Math.max(x1,p.x); y1=Math.max(y1,p.y); }
+  const bw = Math.max(x1-x0, 1e-6), bh = Math.max(y1-y0, 1e-6);
+  const zone = { x: w*0.52, y: h*0.22, w: w*0.36, h: h*0.56 };
+  const k = Math.min(zone.w/bw, zone.h/bh);
+  return { k,
+    ox: zone.x + (zone.w - bw*k)/2 - x0*k,
+    oy: zone.y + (zone.h - bh*k)/2 - y0*k };
+}
+function setTf(tf){ state.tf = tf; }
+function animateTf(to, done){
+  const from = { ...state.tf }, t0 = performance.now(), dur = 380;
+  function step(t){
+    const u = Math.min(1, (t-t0)/dur), e = 1-Math.pow(1-u,3);
+    setTf({ k: from.k+(to.k-from.k)*e, ox: from.ox+(to.ox-from.ox)*e, oy: from.oy+(to.oy-from.oy)*e });
+    render();
+    if (u < 1) requestAnimationFrame(step); else if (done) done();
+  }
+  requestAnimationFrame(step);
+}
+
+/* ======================= rendering the plate ======================= */
+function render(){
+  const pred = PREDS[state.current];
+  const theme = THEMES[state.current];
+  pred.derive(state.pts);
+  const { w, h } = plateSize();
+  svg.innerHTML = '';
+  $('#plate').style.background = theme.bg;
+
+  // shapes — lines run off the page; circles are drawn whole
+  for (const s of pred.shapes(state.pts)){
+    const color = theme.strokes[s.ci % theme.strokes.length];
+    if (s.kind === 'circle'){
+      const c = toScreen(s.c);
+      el('circle', { cx:c.x, cy:c.y, r:s.r*state.tf.k, fill:'none',
+        stroke:color, 'stroke-width':4,
+        class:'shape' + (s.dim?' dim':''), 'data-ref':s.ref }, svg);
+    } else {
+      const a = toScreen(s.a), b = toScreen(s.b);
+      const d = V.norm(V.sub(b,a));
+      const p1 = V.sub(a, V.mul(d, 4000)), p2 = V.add(a, V.mul(d, 4000));
+      el('line', { x1:p1.x, y1:p1.y, x2:p2.x, y2:p2.y,
+        stroke:color, 'stroke-width':4,
+        class:'shape' + (s.dim?' dim':''), 'data-ref':s.ref }, svg);
+    }
+  }
+
+  // points + labels
+  const names = pred.args.concat(pred.aux);
+  for (const n of names){
+    const isAux = pred.aux.includes(n);
+    const p = toScreen(state.pts[n]);
+    const g = el('g', { class: isAux ? 'aux' : '' }, svg);
+    el('circle', { cx:p.x, cy:p.y, r: isAux?5:8,
+      fill: theme.pt, stroke: theme.ptRim, 'stroke-width':2.5,
+      class:'ptdot' + (pred.free[n] ? ' free':''), 'data-point':n }, g);
+    const t = el('text', { x:p.x+14, y:p.y+7, class:'ptlabel',
+      fill: pointColor(n), 'data-point':n }, g);
+    t.textContent = n;
+  }
+}
+
+function pointColor(name){
+  const pred = PREDS[state.current], theme = THEMES[state.current];
+  const names = pred.args.concat(pred.aux);
+  return theme.code[names.indexOf(name) % theme.code.length];
+}
+
+/* ======================= code as typography ======================= */
+function renderCode(){
+  const pred = PREDS[state.current], theme = THEMES[state.current];
+  codeblock.style.color = theme.ink;
+  let html = '';
+  const span = n => `<span class="pt" data-point="${n}" style="color:${pointColor(n)}">${n}</span>`;
+  html += `<div class="clause head"><span class="pred">${state.current}</span> `
+        + pred.args.map(span).join(' ')
+        + `:<span class="tick" id="proof-tick">✓<span class="tlabel">view trace</span></span></div>`;
+  for (const b of pred.body){
+    const [p, ...as] = b.text;
+    html += `<div class="clause body" data-shape="${b.ref}"><span class="pred">${p}</span> `
+          + as.map(span).join(' ') + `</div>`;
+  }
+  codeblock.innerHTML = html;
+  $('#proof-tick').addEventListener('click', e => { e.stopPropagation(); openBoffin(); });
+}
+
+/* Adaptive positioning: fixed left anchor, ~12 candidate y positions,
+   least-overlap wins, hysteresis so small drags don't cause drift. */
+function overlapScore(rect){
+  const pred = PREDS[state.current];
+  const shapes = pred.shapes(state.pts);
+  let score = 0;
+  const sx = 5, sy = 7;
+  for (let i=0;i<=sx;i++) for (let j=0;j<=sy;j++){
+    const q = { x: rect.x + rect.w*i/sx, y: rect.y + rect.h*j/sy };
+    for (const s of shapes){
+      if (s.kind === 'circle'){
+        const c = toScreen(s.c);
+        if (Math.abs(V.dist(q,c) - s.r*state.tf.k) < 26) score += s.dim?0.4:1;
+      } else {
+        const a = toScreen(s.a), b = toScreen(s.b);
+        const d = V.norm(V.sub(b,a));
+        const t = (q.x-a.x)*d.x + (q.y-a.y)*d.y;
+        const f = V.add(a, V.mul(d,t));
+        if (V.dist(q,f) < 22) score += 1;
+      }
+    }
+    for (const n of pred.args.concat(pred.aux))
+      if (V.dist(q, toScreen(state.pts[n])) < 46) score += 2;
+  }
+  return score;
+}
+function placeCode(){
+  const { h } = plateSize();
+  const cb = codeblock.getBoundingClientRect();
+  const plate = $('#plate').getBoundingClientRect();
+  const cw = cb.width, ch = cb.height;
+  const lo = 70, hi = Math.max(lo+1, h - ch - 50);
+  let best = null, bestScore = 1e9, current = null;
+  for (let i=0;i<=12;i++){
+    const y = lo + (hi-lo)*i/12;
+    const s = overlapScore({ x:48, y, w:cw, h:ch });
+    if (state.codeTop !== null && Math.abs(y - state.codeTop) < 14) current = s;
+    if (s < bestScore){ bestScore = s; best = y; }
+  }
+  // hysteresis: only move when meaningfully better
+  if (state.codeTop === null || current === null || current - bestScore > 4){
+    state.codeTop = best;
+    codeblock.style.top = (best / plate.height * 100) + '%';
+  }
+}
+
+/* ======================= hover binding (the tether) ======================= */
+function bindHover(){
+  codeblock.addEventListener('mouseover', e => {
+    const pt = e.target.closest('.pt');
+    const cl = e.target.closest('.clause.body');
+    if (pt) setPointHl(pt.dataset.point, true);
+    else if (cl) setShapeHl(cl.dataset.shape, true);
+  });
+  codeblock.addEventListener('mouseout', e => {
+    const pt = e.target.closest('.pt');
+    const cl = e.target.closest('.clause.body');
+    if (pt) setPointHl(pt.dataset.point, false);
+    else if (cl) setShapeHl(cl.dataset.shape, false);
+  });
+  svg.addEventListener('mouseover', e => {
+    const n = e.target.dataset && e.target.dataset.point;
+    if (n) setPointHl(n, true);
+  });
+  svg.addEventListener('mouseout', e => {
+    const n = e.target.dataset && e.target.dataset.point;
+    if (n) setPointHl(n, false);
+  });
+}
+function setPointHl(name, on){
+  svg.querySelectorAll(`[data-point="${name}"]`).forEach(x => x.classList.toggle('hl', on));
+  codeblock.querySelectorAll(`.pt[data-point="${name}"]`).forEach(x => x.classList.toggle('hl', on));
+  codeblock.classList.toggle('dimmed', on);
+  svg.classList.toggle('dimmed', on);
+}
+function setShapeHl(ref, on){
+  svg.querySelectorAll(`[data-ref="${ref}"]`).forEach(x => x.classList.toggle('hl', on));
+  codeblock.querySelectorAll(`[data-shape="${ref}"]`).forEach(x => x.classList.toggle('hl', on));
+  svg.classList.toggle('dimmed', on);
+}
+
+/* ======================= dragging ======================= */
+let drag = null;
+svg.addEventListener('pointerdown', e => {
+  reveal();   // first touch of the figure brings the interface in
+  const n = e.target.dataset && e.target.dataset.point;
+  if (!n || !PREDS[state.current].free[n]) return;
+  drag = n;
+  e.target.classList.add('dragging');
+  svg.setPointerCapture(e.pointerId);
+});
+svg.addEventListener('pointermove', e => {
+  if (!drag) return;
+  const r = $('#plate').getBoundingClientRect();
+  state.pts[drag] = toModel({ x:e.clientX - r.left, y:e.clientY - r.top });
+  render();
+});
+svg.addEventListener('pointerup', e => {
+  if (!drag) return;
+  drag = null;
+  svg.querySelectorAll('.dragging').forEach(x => x.classList.remove('dragging'));
+  // settle: re-fit the named points into the right zone, then re-place the text
+  animateTf(targetTf(), placeCode);
+});
+
+/* ======================= predicate navigation ======================= */
+function loadPredicate(name){
+  state.current = name;
+  const pred = PREDS[name];
+  state.pts = {};
+  for (const n in pred.free) state.pts[n] = { ...pred.free[n] };
+  pred.derive(state.pts);
+  setTf(targetTf());
+  state.codeTop = null;
+  $('#viewer-name').textContent = name;
+  renderCode();
+  render();
+  requestAnimationFrame(placeCode);
+  renderBoffin();
+}
+function navigate(dir){
+  const i = PRED_ORDER.indexOf(state.current);
+  loadPredicate(PRED_ORDER[(i + dir + PRED_ORDER.length) % PRED_ORDER.length]);
+}
+$('#nav-prev').addEventListener('click', () => navigate(-1));
+$('#nav-next').addEventListener('click', () => navigate(1));
+document.addEventListener('keydown', e => {
+  if (e.target.tagName === 'TEXTAREA' || e.target.tagName === 'INPUT'){
+    if (e.key === 'Escape') e.target.blur();
+    return;
+  }
+  if (e.key === 'ArrowLeft') navigate(-1);
+  if (e.key === 'ArrowRight') navigate(1);
+  if (e.key === '`'){ e.preventDefault(); toggleBoffin(); }
+});
+
+/* ======================= reveal sequence ======================= */
+function reveal(){
+  if (state.revealed) return;
+  state.revealed = true;
+  app.classList.add('revealed');
+  // the strip takes real vertical space — re-settle once it has landed
+  setTimeout(() => { animateTf(targetTf(), placeCode); }, 460);
+}
+
+/* ======================= search ======================= */
+const CORE_STUBS = ['point','line','circle','between','eq-points'];
+function buildCards(filter){
+  const cards = $('#cards');
+  cards.innerHTML = '';
+  const f = (filter||'').toLowerCase();
+  for (const name of PRED_ORDER){
+    if (f && !name.includes(f)) continue;
+    const card = document.createElement('div');
+    card.className = 'card';
+    const theme = THEMES[name];
+    card.style.background = theme.bg;
+    card.innerHTML = `<svg viewBox="0 0 172 96"></svg><span class="cname" style="color:${theme.ink}">${name}</span>`;
+    miniDiagram(card.querySelector('svg'), name);
+    card.addEventListener('click', () => {
+      loadPredicate(name);
+      app.classList.remove('search-open', 'scratch-open');
+      $('#tile-search').classList.remove('active');
+      $('#tile-scratch').classList.remove('active');
+    });
+    cards.appendChild(card);
+  }
+  for (const name of CORE_STUBS){
+    if (f && !name.includes(f)) continue;
+    const card = document.createElement('div');
+    card.className = 'card stub';
+    card.style.background = '#1b1813';
+    card.innerHTML = `<span class="cname" style="color:#f3eee2">${name}</span>`;
+    cards.appendChild(card);
+  }
+}
+function miniDiagram(msvg, name){
+  const pred = PREDS[name], theme = THEMES[name];
+  const pts = {};
+  for (const n in pred.free) pts[n] = { ...pred.free[n] };
+  pred.derive(pts);
+  const names = pred.args.concat(pred.aux);
+  let x0=1e9,y0=1e9,x1=-1e9,y1=-1e9;
+  for (const n of names){ x0=Math.min(x0,pts[n].x); y0=Math.min(y0,pts[n].y);
+                          x1=Math.max(x1,pts[n].x); y1=Math.max(y1,pts[n].y); }
+  const k = Math.min(96/(x1-x0), 52/(y1-y0));
+  const tx = p => ({ x: 50 + (p.x-x0)*k, y: 20 + (p.y-y0)*k });
+  for (const s of pred.shapes(pts)){
+    const color = theme.strokes[s.ci % theme.strokes.length];
+    if (s.kind === 'circle'){
+      const c = tx(s.c);
+      el('circle', { cx:c.x, cy:c.y, r:s.r*k, fill:'none', stroke:color, 'stroke-width':2.5,
+                     opacity: s.dim?0.3:1 }, msvg);
+    } else {
+      const a = tx(s.a), b = tx(s.b), d = V.norm(V.sub(b,a));
+      const p1 = V.sub(a,V.mul(d,300)), p2 = V.add(a,V.mul(d,300));
+      el('line', { x1:p1.x, y1:p1.y, x2:p2.x, y2:p2.y, stroke:color, 'stroke-width':2.5 }, msvg);
+    }
+  }
+  for (const n of names){
+    const p = tx(pts[n]);
+    el('circle', { cx:p.x, cy:p.y, r:3, fill:theme.pt, stroke:theme.ptRim, 'stroke-width':1 }, msvg);
+  }
+}
+$('#tile-search').addEventListener('click', () => {
+  const open = app.classList.toggle('search-open');
+  $('#tile-search').classList.toggle('active', open);
+  if (open){ buildCards(''); $('#search-input').focus(); }
+  setTimeout(() => { setTf(targetTf()); render(); placeCode(); }, 460);
+});
+$('#search-input').addEventListener('input', e => buildCards(e.target.value));
+
+/* ======================= scratchpad ======================= */
+const DEFAULT_SCRATCH =
+`circle a b c
+circle b a c
+line a b m
+
+? eq-lines a b a c
+? eq-lines a b b m
+? equilateral a b c`;
+
+$('#tile-scratch').addEventListener('click', () => {
+  const open = app.classList.toggle('scratch-open');
+  $('#tile-scratch').classList.toggle('active', open);
+  $('#tile-viewer').classList.toggle('active', !open);
+  if (open) runScratch();
+});
+
+const KNOWN = new Set(['circle','line','eq-triangle','eq-lines','between','eq-points','point']);
+
+function runScratch(){
+  const src = $('#editor').value;
+  const lines = src.split('\n');
+  const gutter = [];
+  const facts = [];
+  for (const line of lines){
+    const t = line.trim();
+    if (!t){ gutter.push(''); continue; }
+    const isQuery = t.startsWith('?');
+    const bodyText = isQuery ? t.slice(1).trim() : t;
+    const toks = bodyText.split(/\s+/);
+    const known = KNOWN.has(toks[0]);
+    if (isQuery) gutter.push(known ? '<span class="ok">✓</span>' : '<span class="bad">✗</span>');
+    else { gutter.push(''); if (known) facts.push(toks); }
+  }
+  $('#gutter').innerHTML = gutter.join('<br>');
+  drawScratch(facts);
+}
+
+/* A toy relaxation pass — just enough to make the scratch diagram feel live. */
+function drawScratch(facts){
+  const ssvg = $('#scratch-svg');
+  const pts = {};
+  const seed = n => { let h = 0; for (const ch of n) h = (h*31 + ch.charCodeAt(0)) % 997;
+                      return { x: (h%10)/10 - 0.5, y: ((h*7)%10)/10 - 0.5 }; };
+  const need = n => { if (!pts[n]) pts[n] = seed(n); return pts[n]; };
+  for (let pass=0; pass<24; pass++){
+    for (const f of facts){
+      const [p, ...as] = f;
+      if (p === 'circle' && as.length === 3){
+        const [c, r1, z] = as.map(need);
+        const r = V.dist(c, r1) || 0.5;
+        const d = V.norm(V.sub(z, c));
+        const tgt = V.add(c, V.mul(d, r));
+        pts[as[2]] = V.add(z, V.mul(V.sub(tgt, z), 0.6));
+      } else if (p === 'line' && as.length === 3){
+        const [a, b, z] = as.map(need);
+        const d = V.norm(V.sub(b, a));
+        const t = (z.x-a.x)*d.x + (z.y-a.y)*d.y;
+        const tgt = V.add(a, V.mul(d, t < 0.2 ? t - 0.9 : t));
+        pts[as[2]] = V.add(z, V.mul(V.sub(tgt, z), 0.6));
+      } else if (p === 'eq-triangle' && as.length === 3){
+        const [a, b] = [need(as[0]), need(as[1])]; need(as[2]);
+        pts[as[2]] = V.rot(b, a, -Math.PI/3);
+      } else { as.forEach(need); }
+    }
+  }
+  // render
+  ssvg.innerHTML = '';
+  const r = ssvg.getBoundingClientRect();
+  const names = Object.keys(pts);
+  if (!names.length) return;
+  let x0=1e9,y0=1e9,x1=-1e9,y1=-1e9;
+  for (const n of names){ x0=Math.min(x0,pts[n].x); y0=Math.min(y0,pts[n].y);
+                          x1=Math.max(x1,pts[n].x); y1=Math.max(y1,pts[n].y); }
+  const k = Math.min((r.width*0.5)/Math.max(x1-x0,1e-6), (r.height*0.5)/Math.max(y1-y0,1e-6));
+  const tx = p => ({ x: r.width*0.25 + (p.x-x0)*k, y: r.height*0.25 + (p.y-y0)*k });
+  const SCOL = ['#e09c14','#f3eee2','#d93a1a'];
+  let ci = 0;
+  for (const f of facts){
+    const [p, ...as] = f;
+    const color = SCOL[ci++ % SCOL.length];
+    if (p === 'circle'){
+      const c = tx(pts[as[0]]);
+      el('circle', { cx:c.x, cy:c.y, r:V.dist(pts[as[0]], pts[as[1]])*k, fill:'none',
+                     stroke:color, 'stroke-width':3.5 }, ssvg);
+    } else if (p === 'line'){
+      const a = tx(pts[as[0]]), b = tx(pts[as[1]]);
+      const d = V.norm(V.sub(b,a));
+      const p1 = V.sub(a,V.mul(d,3000)), p2 = V.add(a,V.mul(d,3000));
+      el('line', { x1:p1.x, y1:p1.y, x2:p2.x, y2:p2.y, stroke:color, 'stroke-width':3.5 }, ssvg);
+    }
+  }
+  for (const n of names){
+    const p = tx(pts[n]);
+    el('circle', { cx:p.x, cy:p.y, r:6, fill:'#f3eee2', stroke:'#1b1813', 'stroke-width':2 }, ssvg);
+    const t = el('text', { x:p.x+11, y:p.y+5, fill:'#f3eee2',
+      style:'font-family:var(--font-display);font-size:15px;text-transform:uppercase' }, ssvg);
+    t.textContent = n;
+  }
+}
+let scratchTimer = null;
+$('#editor').addEventListener('input', () => {
+  clearTimeout(scratchTimer);
+  scratchTimer = setTimeout(runScratch, 280);
+});
+
+/* ======================= boffin panel ======================= */
+function renderBoffin(){
+  const pred = PREDS[state.current];
+  $('#bof-plan').textContent = pred.plan.join('\n');
+  $('#bof-solver').textContent = pred.solver;
+  $('#bof-trace').textContent = pred.trace;
+}
+function toggleBoffin(){
+  app.classList.toggle('boffin-open');
+  setTimeout(() => { setTf(targetTf()); render(); placeCode(); }, 460);
+}
+function openBoffin(){
+  if (!app.classList.contains('boffin-open')) toggleBoffin();
+}
+$('#boffin-btn').addEventListener('click', toggleBoffin);
+
+/* ======================= boot ======================= */
+window.addEventListener('resize', () => { setTf(targetTf()); render(); placeCode(); });
+$('#editor').value = DEFAULT_SCRATCH;
+bindHover();
+loadPredicate('eq-triangle');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Synthesizes UI_OVERHAUL_DESIGN.md and EUCLID_STYLE_NOTES.md into a committed design concept, with a self-contained interactive prototype:

- REDESIGN_CONCEPT.md: names the central surface (the plate), defines the tether (ambient colour binding + recession hover), the material five-ink Byrne palette with per-predicate colourways, the five surfaces tiling on one plane, a three-duration motion grammar, and commits answers to the open questions from the vision notes.
- concept-prototype.html: single-file working prototype with real constructive geometry (Euclid I.1 and I.2), draggable points, bidirectional code<->diagram hover binding, adaptive text placement with hysteresis, hero entry sequence, search index with live miniatures, scratchpad with gutter proof marks and a toy live interpreter, and the bottom-revealed boffin underside.

https://claude.ai/code/session_01SbsX5JoCFpYiJHKXM6b8gV